### PR TITLE
cairo: declare dependency on lzo2

### DIFF
--- a/src/cairo-2-script-lzo.patch
+++ b/src/cairo-2-script-lzo.patch
@@ -1,0 +1,26 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Sat, 27 May 2023 20:39:43 +0200
+Subject: [PATCH] add lzo2 dependency to cairo-script
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ configure.ac | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configure.ac b/configure.ac
+index 5e33c96ea..d557452cb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -482,6 +482,7 @@ CAIRO_ENABLE_SURFACE_BACKEND(script, script, yes, [
+   # The script backend requires zlib.
+   use_script=$have_libz
+   script_NONPKGCONFIG_LIBS=-lz
++  script_REQUIRES=lzo2
+ ])
+ 
+ dnl ===========================================================================

--- a/src/cairo-3-autogen.patch
+++ b/src/cairo-3-autogen.patch
@@ -1,0 +1,32 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Sat, 27 May 2023 20:31:20 +0200
+Subject: [PATCH] don't check for gtkdocize when generating configurations
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ autogen.sh | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index 1111111..2222222 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -13,12 +13,7 @@ if test -z $AUTORECONF; then
+         exit 1
+ fi
+ 
+-GTKDOCIZE=`which gtkdocize`
+-if test -z $GTKDOCIZE; then
+-        echo "*** No GTK-Doc found, documentation won't be generated ***"
+-else
+-        gtkdocize || exit $?
+-fi
++export GTKDOCIZE=echo
+ 
+ # create dummy */Makefile.am.features and ChangeLog to make automake happy
+ > boilerplate/Makefile.am.features

--- a/src/cairo.mk
+++ b/src/cairo.mk
@@ -19,6 +19,8 @@ endef
 define $(PKG)_BUILD
     $(SED) -i 's,libpng12,libpng,g'                          '$(1)/configure'
     $(SED) -i 's,^\(Libs:.*\),\1 @CAIRO_NONPKGCONFIG_LIBS@,' '$(1)/src/cairo.pc.in'
+    # regenerate for patch 2 to work
+    cd '$(SOURCE_DIR)' && NOCONFIGURE=true $(SHELL) ./autogen.sh
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
         --disable-lto \


### PR DESCRIPTION
Please read http://mxe.cc/#creating-packages

In particular, make sure that your build rules:

  * install .pc file,
  * install bin/test-pkg.exe compiled with flags by pkg-config,
  * install .dll to bin/ and .a, .dll.a to lib/,
  * use $(TARGET)-cmake instead of cmake,
  * build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
  * do not run target executables with Wine,
  * do not download anything while building,
  * do not install documentation,
  * do not install .exe files except test and build systems,

and .patch files are generated by tools/patch-tool-mxe.

If you add a package, you can use tool tools/skeleton.py.

Thanks!
